### PR TITLE
Update styles/base.less

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -72,7 +72,7 @@ pre {
 .datatip-marked-container {
   color: #000000;
   background-color: #f8cbaee7;
-  font-size: 20px;
+  font-size: 14px;
   max-height: 300px;
   max-width: 500px;
   overflow: auto;


### PR DESCRIPTION
set font size to default.  Lack of feature in atom to get this to pick up the editor font size.